### PR TITLE
Add ECR Repository for index-api

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,5 @@
-module "spring-boot-template" {
+module "index-api" {
   source = "./modules/ecr"
 
-  name = "spring-boot-template"
-}
-
-module "nodejs-template" {
-  source = "./modules/ecr"
-
-  name = "nodejs-template"
+  name = "index-api"
 }


### PR DESCRIPTION
This PR adds a new ECR repository named `index-api` to the Terraform configuration.