### PR TITLE
Add ECR Repository for products-api

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+module "products-api" {
+  source = "./modules/ecr"
+
+  name = "products-api"
+}
+
 module "spring-boot-template" {
   source = "./modules/ecr"
 


### PR DESCRIPTION
This PR adds a new ECR repository named `products-api` to the infra-ecr module.