### PR TITLE
Add tooling-ai ECR repository

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+module "tooling-service" {
+  source = "./modules/ecr"
+
+  name = "tooling-service"
+}
+
 module "spring-boot-template" {
   source = "./modules/ecr"
 


### PR DESCRIPTION
This PR has been updated to change the ECR repository name from `tooling-service` to `tooling-ai`.